### PR TITLE
Prevent a rule from being checked twice + allow overriding external actions

### DIFF
--- a/cmd/octo-linter/main.go
+++ b/cmd/octo-linter/main.go
@@ -243,6 +243,7 @@ func lintHandler(ctx context.Context, cli *broccli.Broccli) int {
 		cli.Flag("path"),
 		cli.Flag("vars-file"),
 		cli.Flag("secrets-file"),
+		lint.Config.Overrides,
 	)
 	if err != nil && errors.Is(err, errDotGithubDirRead) {
 		return ExitErrReadingDotGithubDir
@@ -364,10 +365,19 @@ func getDotGithub(
 	dotGithubPath string,
 	varsFile string,
 	secretsFile string,
+	overrides *linter.Overrides,
 ) (*dotgithub.DotGithub, error) {
 	dotGithub := dotgithub.DotGithub{}
 
-	err := dotGithub.ReadDir(ctx, dotGithubPath)
+	overridePaths := map[string]string{}
+
+	if overrides != nil && len(overrides.ExternalActionsPaths) > 0 {
+		for action, path := range overrides.ExternalActionsPaths {
+			overridePaths[action] = path
+		}
+	}
+
+	err := dotGithub.ReadDir(ctx, dotGithubPath, overridePaths)
 	if err != nil {
 		slog.Error(
 			"error initializing",

--- a/cmd/octo-linter/version.go
+++ b/cmd/octo-linter/version.go
@@ -1,4 +1,4 @@
 package main
 
 // VERSION is application version. It is used with 'version' subcommand.
-const VERSION = "2.3.0"
+const VERSION = "2.4.0"

--- a/docs/add_rule.md
+++ b/docs/add_rule.md
@@ -65,6 +65,33 @@ func (r ActionReferencedStepOutputExists) FileType() int {
 }
 ```
 
+To prevent the rule from running twice, it should have a unique field like `FileTypeRequired` which indicates whether the rule will be used for action or workflow.
+```go
+type NotInDoubleQuotes struct {
+	FileTypeRequired string
+}
+```
+
+In addition, the `Lint` method must have a check for `FileTypeRequired` to ensure the rule is only run for the appropriate file type.
+```go
+func (r NotInDoubleQuotes) Lint(conf interface{}, file dotgithub.File, _ *dotgithub.DotGithub, chErrors chan<- glitch.Glitch) (bool, error) {
+    // ...
+    var fileTypeRequired int
+    if r.FileTypeRequired == "action" {
+        fileTypeRequired = rule.DotGithubFileTypeAction
+    }
+    if r.FileTypeRequired == "workflow" {
+        fileTypeRequired = rule.DotGithubFileTypeWorkflow
+    }
+
+    if file.GetType() != fileTypeRequired {
+        return true, nil
+    }
+    // ...
+}
+
+```
+
 #### ConfigName method
 This method can vary depending on whether the rule struct handles:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,16 @@ rules:
 ### Warning instead of an error
 A non-compliant rule can be treated either as an error or a warning. If a rule is intended to trigger only a warning, it should be included in the `warning_only` list, as shown on above example under the `filenames` rule group.
 
+### Override external action
+When a GitHub action that is private is used, octo-linter will not be able to download it. In such cases, it is possible to override the action with a local copy.
+To do so, add the action to the `overrides.external_actions_paths` list. See an example below.
+
+````yaml
+overrides:
+  external_actions_paths:
+    my-organisation/repo-name@v1: ../repo-name
+````
+
 ### Version compatibility
 The latest `v2` version of the application supports only configuration version `'3'`. Older configuration versions are no longer supported and would 
 require using the previous `v1` release of octo-linter.

--- a/example/config-2.yml
+++ b/example/config-2.yml
@@ -22,12 +22,14 @@ rules:
 
   used_actions_in_action_steps:
     source: local-or-external
+    must_exist: ['local', 'external']
+    must_have_valid_inputs: true
   
   used_actions_in_workflow_job_steps:
     source: local-only
 
   dependencies: # Verify that all referenced inputs, outputs, and similar entities are properly defined
-    action_referenced_input_must_exists: true 
+    action_referenced_input_must_exists: true
     action_referenced_step_output_must_exist: true
     workflow_referenced_input_must_exists: true
     workflow_referenced_variable_must_exists_in_attached_file: true

--- a/example/config-2.yml
+++ b/example/config-2.yml
@@ -20,8 +20,8 @@ rules:
   referenced_variables_in_actions:
     not_in_double_quotes: true # Named-value variables should not be enclosed in double quotes
 
-  used_actions_in_action_steps: # Only local actions should be used
-    source: local-only
+  used_actions_in_action_steps:
+    source: local-or-external
   
   used_actions_in_workflow_job_steps:
     source: local-only
@@ -37,4 +37,4 @@ rules:
 
 overrides:
   external_actions_paths:
-    mikolajgasior/read-from-local-path: ./overrides/local-source
+    mikolajgasior/read-from-local-path@v1: ./overrides/local-source

--- a/example/config.yml
+++ b/example/config.yml
@@ -34,3 +34,7 @@ rules:
 
   workflow_runners:
     not_latest: true # The use of the latest runner version should be avoided
+
+overrides:
+  external_actions_paths:
+    mikolajgasior/read-from-local-path: ./overrides/mikolajgasior/read-from-local-path

--- a/example/dot-github-2/actions/some-action/action.yml
+++ b/example/dot-github-2/actions/some-action/action.yml
@@ -1,0 +1,46 @@
+---
+name: Action with valid name
+description: Some description
+inputs:
+  some-input1:
+    description: Some input
+    required: true
+  output-without-description:
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: Step where non-existing input is called and not in double quote
+      shell: bash
+      run: |
+        echo "${{ inputs.non-existing }}"
+
+    - name: Step where existing input is called
+      shell: bash
+      env:
+        InvalidEnvName: abc123
+      run: |
+        echo '${{ inputs.some-input1 }}'
+
+    - name: Step that sets output
+      shell: bash
+      id: existing-step
+      run: |
+        echo "output1=abc123" >> $GITHUB_OUTPUT
+
+    - name: Use of non-existing step
+      shell: bash
+      run: |
+        echo '${{ steps.non-existing-step.outputs.output1 }}'
+
+    - name: Use of existing step
+      shell: bash
+      run: |
+        echo '${{ steps.existing-step.outputs.output1 }}'
+
+    - name: Calling external action overridden from local source
+      uses: mikolajgasior/read-from-local-path@v1

--- a/example/dot-github-2/actions/some-action/action.yml
+++ b/example/dot-github-2/actions/some-action/action.yml
@@ -1,12 +1,6 @@
 ---
 name: Action with valid name
 description: Some description
-inputs:
-  some-input1:
-    description: Some input
-    required: true
-  output-without-description:
-    required: false
 
 runs:
   using: "composite"
@@ -14,33 +8,7 @@ runs:
     - name: Checkout source code
       uses: actions/checkout@v4
 
-    - name: Step where non-existing input is called and not in double quote
-      shell: bash
-      run: |
-        echo "${{ inputs.non-existing }}"
-
-    - name: Step where existing input is called
-      shell: bash
-      env:
-        InvalidEnvName: abc123
-      run: |
-        echo '${{ inputs.some-input1 }}'
-
-    - name: Step that sets output
-      shell: bash
-      id: existing-step
-      run: |
-        echo "output1=abc123" >> $GITHUB_OUTPUT
-
-    - name: Use of non-existing step
-      shell: bash
-      run: |
-        echo '${{ steps.non-existing-step.outputs.output1 }}'
-
-    - name: Use of existing step
-      shell: bash
-      run: |
-        echo '${{ steps.existing-step.outputs.output1 }}'
-
     - name: Calling external action overridden from local source
       uses: mikolajgasior/read-from-local-path@v1
+      #with:
+      #  local-src-input-1: "abc123"

--- a/example/overrides/local-source/action.yml
+++ b/example/overrides/local-source/action.yml
@@ -5,8 +5,10 @@ inputs:
   local-src-input-1:
     description: Some input
     required: true
+outputs:
   local-src-output-2:
-    value: 4
+    description: Some output
+    value: "4"
 
 runs:
   using: "composite"

--- a/example/overrides/local-source/action.yml
+++ b/example/overrides/local-source/action.yml
@@ -1,0 +1,20 @@
+---
+name: Action from local source
+description: Some description
+inputs:
+  local-src-input-1:
+    description: Some input
+    required: true
+  local-src-output-2:
+    value: 4
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: Nothing important
+      shell: bash
+      run: |
+        echo "nothing important"

--- a/gen.go
+++ b/gen.go
@@ -36,12 +36,14 @@ func main() {
 		Rules: map[string]S{
 			"filenames__action_filename_extensions_allowed": {
 				N: "filenames.FilenameExtensionsAllowed",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"filenames__action_directory_name_format": {
 				N: "filenames.ActionDirectoryNameFormat",
 			},
 			"filenames__workflow_filename_extensions_allowed": {
 				N: "filenames.FilenameExtensionsAllowed",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"filenames__workflow_filename_base_format": {
 				N: "filenames.WorkflowFilenameBaseFormat",
@@ -51,21 +53,26 @@ func main() {
 			},
 			"referenced_variables_in_actions__not_one_word": {
 				N: "refvars.NotOneWord",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"referenced_variables_in_actions__not_in_double_quotes": {
 				N: "refvars.NotInDoubleQuotes",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"referenced_variables_in_workflows__not_one_word": {
 				N: "refvars.NotOneWord",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"referenced_variables_in_workflows__not_in_double_quotes": {
 				N: "refvars.NotInDoubleQuotes",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"dependencies__workflow_needs_field_must_contain_already_existing_jobs": {
 				N: "dependencies.WorkflowNeedsWithExistingJobs",
 			},
 			"dependencies__action_referenced_input_must_exists": {
 				N: "dependencies.ReferencedInputExists",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"dependencies__action_referenced_step_output_must_exist": {
 				N: "dependencies.ActionReferencedStepOutputExists",
@@ -75,24 +82,31 @@ func main() {
 			},
 			"dependencies__workflow_referenced_input_must_exists": {
 				N: "dependencies.ReferencedInputExists",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"used_actions_in_action_steps__source": {
 				N: "usedactions.Source",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"used_actions_in_action_steps__must_exist": {
 				N: "usedactions.Exists",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"used_actions_in_action_steps__must_have_valid_inputs": {
 				N: "usedactions.ValidInputs",
+				F: map[string]string{"FileTypeRequired": `"action"`},
 			},
 			"used_actions_in_workflow_job_steps__source": {
 				N: "usedactions.Source",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"used_actions_in_workflow_job_steps__must_exist": {
 				N: "usedactions.Exists",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"used_actions_in_workflow_job_steps__must_have_valid_inputs": {
 				N: "usedactions.ValidInputs",
+				F: map[string]string{"FileTypeRequired": `"workflow"`},
 			},
 			"naming_conventions__action_input_name_format": {
 				N: "naming.Action",

--- a/internal/linter/config.go
+++ b/internal/linter/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/mikolajgasior/octo-linter/v2/internal/linter/rule"
 	"gopkg.in/yaml.v2"
@@ -21,6 +22,7 @@ type Config struct {
 	Rules       []rule.Rule                       `yaml:"-"`
 	Values      []interface{}                     `yaml:"-"`
 	WarningOnly map[string]struct{}               `yaml:"-"`
+	Overrides   *Overrides                        `yaml:"overrides,omitempty"`
 }
 
 // GetDefaultConfig returns a default configuration file.
@@ -102,6 +104,23 @@ func (cfg *Config) readBytesAndValidate(b []byte) error {
 			err := cfg.addRuleFromConfig(fullRuleName, ruleConfig)
 			if err != nil {
 				return fmt.Errorf("rule %s has invalid config: %w", fullRuleName, err)
+			}
+		}
+	}
+
+	if cfg.Overrides == nil {
+		return nil
+	}
+
+	if len(cfg.Overrides.ExternalActionsOutputsConfig) > 0 {
+		cfg.Overrides.ExternalActionsOutputs = make(map[string][]*regexp.Regexp, len(cfg.Overrides.ExternalActionsOutputsConfig))
+		for actionPath, output := range cfg.Overrides.ExternalActionsOutputsConfig {
+			cfg.Overrides.ExternalActionsOutputs[actionPath] = make([]*regexp.Regexp, len(output))
+			for i, outputRegex := range output {
+				cfg.Overrides.ExternalActionsOutputs[actionPath][i], err = regexp.Compile(outputRegex)
+				if err != nil {
+					return fmt.Errorf("error compiling external action output regex %s: %w", outputRegex, err)
+				}
 			}
 		}
 	}

--- a/internal/linter/dotgithub.yml
+++ b/internal/linter/dotgithub.yml
@@ -75,3 +75,9 @@ rules:
     not_latest: true
     warning_only:
       - not_latest
+
+overrides:
+  external_actions_outputs:
+    aws-actions/amazon-ecr-login:
+      - ^docker_(username|password)_[0-9]+_dkr_ecr_aws_[a-z1-6_]+_amazonaws_com$
+      - ^docker_(username|password)_public_ecr_aws$

--- a/internal/linter/overrides.go
+++ b/internal/linter/overrides.go
@@ -1,0 +1,9 @@
+package linter
+
+import "regexp"
+
+type Overrides struct {
+	ExternalActionsOutputsConfig map[string][]string         `yaml:"external_actions_outputs,omitempty"`
+	ExternalActionsOutputs       map[string][]*regexp.Regexp `yaml:"-"`
+	ExternalActionsPaths         map[string]string           `yaml:"external_actions_paths,omitempty"`
+}

--- a/internal/linter/rule/dependencies/referenced_input_exists.go
+++ b/internal/linter/rule/dependencies/referenced_input_exists.go
@@ -14,7 +14,9 @@ import (
 // ReferencedInputExists scans the code for all input references and verifies that each has been previously defined.
 // During action or workflow execution, if a reference to an undefined input is found, it is replaced with an empty
 // string.
-type ReferencedInputExists struct{}
+type ReferencedInputExists struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r ReferencedInputExists) ConfigName(t int) string {
@@ -56,8 +58,15 @@ func (r ReferencedInputExists) Lint(
 		return false, errValueNotBool
 	}
 
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 

--- a/internal/linter/rule/dependencies/referenced_input_exists_test.go
+++ b/internal/linter/rule/dependencies/referenced_input_exists_test.go
@@ -31,7 +31,9 @@ func TestReferencedInputExistsValidate(t *testing.T) {
 func TestReferencedInputExistsActionNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ReferencedInputExists{}
+	rule := ReferencedInputExists{
+		FileTypeRequired: "action",
+	}
 	d := ruletest.GetDotGithub()
 	conf := true
 
@@ -62,7 +64,9 @@ func TestReferencedInputExistsActionNotCompliant(t *testing.T) {
 func TestReferencedInputExistsActionCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ReferencedInputExists{}
+	rule := ReferencedInputExists{
+		FileTypeRequired: "action",
+	}
 	d := ruletest.GetDotGithub()
 	conf := true
 
@@ -93,7 +97,9 @@ func TestReferencedInputExistsActionCompliant(t *testing.T) {
 func TestReferencedInputExistsWorkflowNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ReferencedInputExists{}
+	rule := ReferencedInputExists{
+		FileTypeRequired: "workflow",
+	}
 	d := ruletest.GetDotGithub()
 	conf := true
 
@@ -124,7 +130,9 @@ func TestReferencedInputExistsWorkflowNotCompliant(t *testing.T) {
 func TestReferencedInputExistsWorkflowCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ReferencedInputExists{}
+	rule := ReferencedInputExists{
+		FileTypeRequired: "workflow",
+	}
 	d := ruletest.GetDotGithub()
 	conf := true
 

--- a/internal/linter/rule/filenames/filename_extensions_allowed.go
+++ b/internal/linter/rule/filenames/filename_extensions_allowed.go
@@ -11,7 +11,9 @@ import (
 )
 
 // FilenameExtensionsAllowed checks if file extension is one of the specific values, eg. 'yml' or 'yaml'.
-type FilenameExtensionsAllowed struct{}
+type FilenameExtensionsAllowed struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r FilenameExtensionsAllowed) ConfigName(t int) string {
@@ -59,8 +61,15 @@ func (r FilenameExtensionsAllowed) Lint(
 	_ *dotgithub.DotGithub,
 	chErrors chan<- glitch.Glitch,
 ) (bool, error) {
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 

--- a/internal/linter/rule/filenames/filename_extensions_allowed_test.go
+++ b/internal/linter/rule/filenames/filename_extensions_allowed_test.go
@@ -35,58 +35,73 @@ func TestFilenameExtensionsAllowedValidate(t *testing.T) {
 func TestFilenameExtensionsAllowedNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := FilenameExtensionsAllowed{}
-	conf := []interface{}{"yaml"}
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := FilenameExtensionsAllowed{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := []interface{}{"yaml"}
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"FilenameExtensionsAllowed.Lint should return false when filename extension is not in config",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"FilenameExtensionsAllowed.Lint should return false when filename extension is not in config",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("FilenameExtensionsAllowed.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) == 0 {
+				t.Errorf("FilenameExtensionsAllowed.Lint should send an error over the channel")
+			}
 		}
 
-		if err != nil {
-			t.Errorf("FilenameExtensionsAllowed.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) == 0 {
-			t.Errorf("FilenameExtensionsAllowed.Lint should send an error over the channel")
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "valid-action", fn)
+		} else {
+			ruletest.Workflow(d, "valid-workflow.yml", fn)
 		}
 	}
 
-	ruletest.Action(d, "valid-action", fn)
-	ruletest.Workflow(d, "valid-workflow.yml", fn)
 }
 
 func TestFilenameExtensionsAllowedCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := FilenameExtensionsAllowed{}
-	conf := []interface{}{"yml"}
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := FilenameExtensionsAllowed{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := []interface{}{"yml"}
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if !compliant {
-			t.Errorf(
-				"FilenameExtensionsAllowed.Lint should return true when filename extension is in config",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if !compliant {
+				t.Errorf(
+					"FilenameExtensionsAllowed.Lint should return true when filename extension is in config",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("FilenameExtensionsAllowed.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) > 0 {
+				t.Errorf(
+					"FilenameExtensionsAllowed.Lint should not send any error over the channel, sent %s",
+					strings.Join(ruleErrors, "|"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("FilenameExtensionsAllowed.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) > 0 {
-			t.Errorf(
-				"FilenameExtensionsAllowed.Lint should not send any error over the channel, sent %s",
-				strings.Join(ruleErrors, "|"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "valid-action", fn)
+		} else {
+			ruletest.Workflow(d, "valid-workflow.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "valid-action", fn)
-	ruletest.Workflow(d, "valid-workflow.yml", fn)
 }

--- a/internal/linter/rule/refvars/not_in_double_quotes.go
+++ b/internal/linter/rule/refvars/not_in_double_quotes.go
@@ -10,7 +10,9 @@ import (
 
 // NotInDoubleQuotes scans for all variable references enclosed in double quotes. It is safer to use single quotes, as
 // double quotes expand certain characters and may allow the execution of sub-commands.
-type NotInDoubleQuotes struct{}
+type NotInDoubleQuotes struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r NotInDoubleQuotes) ConfigName(t int) string {
@@ -52,8 +54,15 @@ func (r NotInDoubleQuotes) Lint(
 		return false, errValueNotBool
 	}
 
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 

--- a/internal/linter/rule/refvars/not_in_double_quotes_test.go
+++ b/internal/linter/rule/refvars/not_in_double_quotes_test.go
@@ -31,58 +31,72 @@ func TestNotInDoubleQuotesValidate(t *testing.T) {
 func TestNotInDoubleQuotesNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := NotInDoubleQuotes{}
-	conf := true
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := NotInDoubleQuotes{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := true
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"NotInDoubleQuotes.Lint should return false when there is a variable in double quotes",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"NotInDoubleQuotes.Lint should return false when there is a variable in double quotes",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("NotInDoubleQuotes.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) == 0 {
+				t.Errorf("NotInDoubleQuotes.Lint should send an error over the channel")
+			}
 		}
 
-		if err != nil {
-			t.Errorf("NotInDoubleQuotes.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) == 0 {
-			t.Errorf("NotInDoubleQuotes.Lint should send an error over the channel")
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "refvars-not-in-double-quotes", fn)
+		} else {
+			ruletest.Workflow(d, "refvars-not-in-double-quotes.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "refvars-not-in-double-quotes", fn)
-	ruletest.Workflow(d, "refvars-not-in-double-quotes.yml", fn)
 }
 
 func TestNotInDoubleQuotesCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := NotInDoubleQuotes{}
-	conf := true
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := NotInDoubleQuotes{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := true
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if !compliant {
-			t.Errorf(
-				"NotInDoubleQuotes.Lint should return true when there are not any vars that are in double quotes",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if !compliant {
+				t.Errorf(
+					"NotInDoubleQuotes.Lint should return true when there are not any vars that are in double quotes",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("NotInDoubleQuotes.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) > 0 {
+				t.Errorf(
+					"NotInDoubleQuotes.Lint should not send any error over the channel, sent %s",
+					strings.Join(ruleErrors, "|"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("NotInDoubleQuotes.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) > 0 {
-			t.Errorf(
-				"NotInDoubleQuotes.Lint should not send any error over the channel, sent %s",
-				strings.Join(ruleErrors, "|"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "valid-action", fn)
+		} else {
+			ruletest.Workflow(d, "valid-workflow.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "valid-action", fn)
-	ruletest.Workflow(d, "valid-workflow.yml", fn)
 }

--- a/internal/linter/rule/refvars/not_one_word.go
+++ b/internal/linter/rule/refvars/not_one_word.go
@@ -11,7 +11,9 @@ import (
 // NotOneWord checks for variable references that are single-word or single-level, e.g. `${{ something }}` instead of
 // `${{ inputs.something }}`.
 // Only the values `true` and `false` are permitted in this form; all other variables are considered invalid.
-type NotOneWord struct{}
+type NotOneWord struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r NotOneWord) ConfigName(t int) string {
@@ -53,11 +55,17 @@ func (r NotOneWord) Lint(
 		return false, errValueNotBool
 	}
 
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
-		return true, nil
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
 	}
 
+	if file.GetType() != fileTypeRequired {
+		return true, nil
+	}
 	if !confValue {
 		return true, nil
 	}

--- a/internal/linter/rule/refvars/not_one_word_test.go
+++ b/internal/linter/rule/refvars/not_one_word_test.go
@@ -31,58 +31,72 @@ func TestNotOneWordValidate(t *testing.T) {
 func TestNotOneWordNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := NotOneWord{}
-	conf := true
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := NotOneWord{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := true
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"NotOneWord.Lint should return false when there is a reference to a 'one-word' variable",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"NotOneWord.Lint should return false when there is a reference to a 'one-word' variable",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("NotOneWord.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) == 0 {
+				t.Errorf("NotOneWord.Lint should send an error over the channel")
+			}
 		}
 
-		if err != nil {
-			t.Errorf("NotOneWord.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) == 0 {
-			t.Errorf("NotOneWord.Lint should send an error over the channel")
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "refvars-not-one-word", fn)
+		} else {
+			ruletest.Workflow(d, "refvars-not-one-word.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "refvars-not-one-word", fn)
-	ruletest.Workflow(d, "refvars-not-one-word.yml", fn)
 }
 
 func TestNotOneWordCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := NotOneWord{}
-	conf := true
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := NotOneWord{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := true
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, _ string) {
-		compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
-		if !compliant {
-			t.Errorf(
-				"NotOneWord.Lint should return true when there are not any vars that are one word",
-			)
+		fn := func(f dotgithub.File, _ string) {
+			compliant, ruleErrors, err := ruletest.Lint(2, rule, conf, f, d)
+			if !compliant {
+				t.Errorf(
+					"NotOneWord.Lint should return true when there are not any vars that are one word",
+				)
+			}
+
+			if err != nil {
+				t.Errorf("NotOneWord.Lint failed with an error: %s", err.Error())
+			}
+
+			if len(ruleErrors) > 0 {
+				t.Errorf(
+					"NotOneWord.Lint should not send any error over the channel, sent %s",
+					strings.Join(ruleErrors, "|"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("NotOneWord.Lint failed with an error: %s", err.Error())
-		}
-
-		if len(ruleErrors) > 0 {
-			t.Errorf(
-				"NotOneWord.Lint should not send any error over the channel, sent %s",
-				strings.Join(ruleErrors, "|"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "valid-action", fn)
+		} else {
+			ruletest.Workflow(d, "valid-workflow.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "valid-action", fn)
-	ruletest.Workflow(d, "valid-workflow.yml", fn)
 }

--- a/internal/linter/rule/usedactions/exists.go
+++ b/internal/linter/rule/usedactions/exists.go
@@ -14,7 +14,9 @@ import (
 )
 
 // Exists verifies that the action referenced in a step actually exists.
-type Exists struct{}
+type Exists struct {
+	FileTypeRequired string
+}
 
 var errConfValue = errors.New("config value is invalid")
 
@@ -68,8 +70,15 @@ func (r Exists) Lint(
 	dotGithub *dotgithub.DotGithub,
 	chErrors chan<- glitch.Glitch,
 ) (bool, error) {
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 

--- a/internal/linter/rule/usedactions/exists_test.go
+++ b/internal/linter/rule/usedactions/exists_test.go
@@ -35,89 +35,110 @@ func TestExistsValidate(t *testing.T) {
 func TestLocal(t *testing.T) {
 	t.Parallel()
 
-	rule := Exists{}
-	conf := []interface{}{"local"}
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Exists{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := []interface{}{"local"}
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+			}
+
+			if err != nil {
+				t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 2 {
+				t.Errorf(
+					"Exists.Lint on %s should send 2 errors over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 2 {
-			t.Errorf(
-				"Exists.Lint on %s should send 2 errors over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-exists", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-exists.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-exists", fn)
-	ruletest.Workflow(d, "usedactions-exists.yml", fn)
 }
 
 func TestExternal(t *testing.T) {
 	t.Parallel()
 
-	rule := Exists{}
-	conf := []interface{}{"external"}
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Exists{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := []interface{}{"external"}
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+			}
+
+			if err != nil {
+				t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 2 {
+				t.Errorf(
+					"Exists.Lint on %s should send 2 errors over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 2 {
-			t.Errorf(
-				"Exists.Lint on %s should send 2 errors over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-exists", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-exists.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-exists", fn)
-	ruletest.Workflow(d, "usedactions-exists.yml", fn)
 }
 
 func TestLocalExternal(t *testing.T) {
 	t.Parallel()
 
-	rule := Exists{}
-	conf := []interface{}{"local", "external"}
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Exists{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := []interface{}{"local", "external"}
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf("Exists.Lint on %s should return false when conf is %v", n, conf)
+			}
+
+			if err != nil {
+				t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 4 {
+				t.Errorf(
+					"Exists.Lint on %s should send 4 errors over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Exists.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 4 {
-			t.Errorf(
-				"Exists.Lint on %s should send 4 errors over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-exists", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-exists.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-exists", fn)
-	ruletest.Workflow(d, "usedactions-exists.yml", fn)
 }

--- a/internal/linter/rule/usedactions/source.go
+++ b/internal/linter/rule/usedactions/source.go
@@ -13,7 +13,9 @@ import (
 
 // Source checks if referenced action (in `uses`) in steps has valid path.
 // This rule can be configured to allow local actions, external actions, or both.
-type Source struct{}
+type Source struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r Source) ConfigName(t int) string {
@@ -60,8 +62,15 @@ func (r Source) Lint(
 		return false, errValueNotString
 	}
 
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 

--- a/internal/linter/rule/usedactions/source_test.go
+++ b/internal/linter/rule/usedactions/source_test.go
@@ -31,102 +31,123 @@ func TestSourceValidate(t *testing.T) {
 func TestLocalOnly(t *testing.T) {
 	t.Parallel()
 
-	rule := Source{}
-	conf := ValueLocalOnly
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Source{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := ValueLocalOnly
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"Source.Lint on %s should return false when there are external actions and conf is %v",
-				n,
-				conf,
-			)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"Source.Lint on %s should return false when there are external actions and conf is %v",
+					n,
+					conf,
+				)
+			}
+
+			if err != nil {
+				t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 3 {
+				t.Errorf(
+					"Source.Lint on %s should send 3 errors over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 3 {
-			t.Errorf(
-				"Source.Lint on %s should send 3 errors over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-source", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-source.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-source", fn)
-	ruletest.Workflow(d, "usedactions-source.yml", fn)
 }
 
 func TestExternalOnlyOnAction(t *testing.T) {
 	t.Parallel()
 
-	rule := Source{}
-	conf := ValueExternalOnly
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Source{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := ValueExternalOnly
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"Source.Lint on %s should return false when there are local actions and conf is %v",
-				n,
-				conf,
-			)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"Source.Lint on %s should return false when there are local actions and conf is %v",
+					n,
+					conf,
+				)
+			}
+
+			if err != nil {
+				t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 2 {
+				t.Errorf(
+					"Source.Lint on %s should send 2 errors over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 2 {
-			t.Errorf(
-				"Source.Lint on %s should send 2 errors over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-source", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-source.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-source", fn)
-	ruletest.Workflow(d, "usedactions-source.yml", fn)
 }
 
 func TestLocalOrExternalOnAction(t *testing.T) {
 	t.Parallel()
 
-	rule := Source{}
-	conf := ValueLocalOrExternal
-	d := ruletest.GetDotGithub()
+	for _, fileTypeRequired := range []string{"action", "workflow"} {
+		rule := Source{
+			FileTypeRequired: fileTypeRequired,
+		}
+		conf := ValueLocalOrExternal
+		d := ruletest.GetDotGithub()
 
-	fn := func(f dotgithub.File, n string) {
-		compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
-		if compliant {
-			t.Errorf(
-				"Source.Lint on %s should return false when there are invalid actions that are nor local nor external, and"+
-					" conf is %v",
-				n,
-				conf,
-			)
+		fn := func(f dotgithub.File, n string) {
+			compliant, ruleErrors, err := ruletest.Lint(3, rule, conf, f, d)
+			if compliant {
+				t.Errorf(
+					"Source.Lint on %s should return false when there are invalid actions that are nor local nor external, and"+
+						" conf is %v",
+					n,
+					conf,
+				)
+			}
+
+			if err != nil {
+				t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
+			}
+
+			if len(ruleErrors) != 1 {
+				t.Errorf(
+					"Source.Lint on %s should send 1 error over the channel not [%s]",
+					n,
+					strings.Join(ruleErrors, "\n"),
+				)
+			}
 		}
 
-		if err != nil {
-			t.Errorf("Source.Lint on %s failed with an error: %s", n, err.Error())
-		}
-
-		if len(ruleErrors) != 1 {
-			t.Errorf(
-				"Source.Lint on %s should send 1 error over the channel not [%s]",
-				n,
-				strings.Join(ruleErrors, "\n"),
-			)
+		if fileTypeRequired == "action" {
+			ruletest.Action(d, "usedactions-source", fn)
+		} else {
+			ruletest.Workflow(d, "usedactions-source.yml", fn)
 		}
 	}
-
-	ruletest.Action(d, "usedactions-source", fn)
-	ruletest.Workflow(d, "usedactions-source.yml", fn)
 }

--- a/internal/linter/rule/usedactions/valid_inputs.go
+++ b/internal/linter/rule/usedactions/valid_inputs.go
@@ -14,7 +14,9 @@ import (
 
 // ValidInputs verifies that all required inputs are provided when referencing an action in a step, and that no
 // undefined inputs are used.
-type ValidInputs struct{}
+type ValidInputs struct {
+	FileTypeRequired string
+}
 
 // ConfigName returns the name of the rule as defined in the configuration file.
 func (r ValidInputs) ConfigName(t int) string {
@@ -56,8 +58,15 @@ func (r ValidInputs) Lint(
 		return false, errValueNotBool
 	}
 
-	if file.GetType() != rule.DotGithubFileTypeAction &&
-		file.GetType() != rule.DotGithubFileTypeWorkflow {
+	var fileTypeRequired int
+	if r.FileTypeRequired == "action" {
+		fileTypeRequired = rule.DotGithubFileTypeAction
+	}
+	if r.FileTypeRequired == "workflow" {
+		fileTypeRequired = rule.DotGithubFileTypeWorkflow
+	}
+
+	if file.GetType() != fileTypeRequired {
 		return true, nil
 	}
 
@@ -199,7 +208,6 @@ func (r ValidInputs) processSteps(
 		if ok {
 			errPrefix = newErrPrefix
 		}
-
 		stepAction := r.getStepFromStepUses(step.Uses, dotGithub)
 		if stepAction == nil {
 			continue
@@ -242,10 +250,8 @@ func (r ValidInputs) getStepFromStepUses(
 	if stepUses == "" {
 		return nil
 	}
-
 	isLocal := regexpLocalAction.MatchString(stepUses)
-	isExternal := regexpLocalAction.MatchString(stepUses)
-
+	isExternal := regexpExternalAction.MatchString(stepUses)
 	if isLocal {
 		actionName := strings.ReplaceAll(stepUses, "./.github/actions/", "")
 

--- a/internal/linter/rule/usedactions/valid_inputs_test.go
+++ b/internal/linter/rule/usedactions/valid_inputs_test.go
@@ -35,7 +35,9 @@ func TestValidInputsValidate(t *testing.T) {
 func TestValidInputsNotCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ValidInputs{}
+	rule := ValidInputs{
+		FileTypeRequired: "workflow",
+	}
 	conf := true
 	d := ruletest.GetDotGithub()
 
@@ -62,7 +64,9 @@ func TestValidInputsNotCompliant(t *testing.T) {
 func TestValidInputsCompliant(t *testing.T) {
 	t.Parallel()
 
-	rule := ValidInputs{}
+	rule := ValidInputs{
+		FileTypeRequired: "workflow",
+	}
 	conf := true
 	d := ruletest.GetDotGithub()
 

--- a/internal/linter/ruletest/ruletest.go
+++ b/internal/linter/ruletest/ruletest.go
@@ -30,7 +30,7 @@ func GetDotGithub() *dotgithub.DotGithub {
 		logger := slog.New(slog.DiscardHandler)
 		slog.SetDefault(logger)
 
-		_ = testDotGithub.ReadDir(context.Background(), "../../../../tests/rules")
+		_ = testDotGithub.ReadDir(context.Background(), "../../../../tests/rules", map[string]string{})
 	})
 
 	return testDotGithub

--- a/pkg/dotgithub/dotgithub.go
+++ b/pkg/dotgithub/dotgithub.go
@@ -53,11 +53,11 @@ func errDoingHTTPRequestForAction(err error) error {
 }
 
 // ReadDir scans the given directory and parses all GitHub Actions workflow and action YAML files into the struct.
-func (d *DotGithub) ReadDir(ctx context.Context, path string) error {
+func (d *DotGithub) ReadDir(ctx context.Context, path string, overridePaths map[string]string) error {
 	d.Actions = make(map[string]*action.Action)
 	d.Workflows = make(map[string]*workflow.Workflow)
 
-	err := d.getActionsFromDir(path)
+	err := d.getActionsFromDir(path, overridePaths)
 	if err != nil {
 		return fmt.Errorf("error getting actions from dir %s: %w", path, err)
 	}
@@ -217,7 +217,7 @@ func (d *DotGithub) IsSecretExist(name string) bool {
 	return ok
 }
 
-func (d *DotGithub) getActionsFromDir(path string) error {
+func (d *DotGithub) getActionsFromDir(path string, overridePaths map[string]string) error {
 	dirActions := filepath.Join(path, "actions")
 
 	entries, err := os.ReadDir(dirActions)
@@ -230,44 +230,42 @@ func (d *DotGithub) getActionsFromDir(path string) error {
 	for _, entry := range entries {
 		dirAction := filepath.Join(dirActions, entry.Name())
 
-		// only directories
-		fileInfo, err := os.Stat(dirAction)
+		ymlAction, err := getActionYAMLFromPath(dirAction)
 		if err != nil {
-			return fmt.Errorf("error getting os.Stat on %s: %w", dirAction, err)
+			return err
 		}
 
-		if !fileInfo.IsDir() {
+		if ymlAction == "" {
 			continue
-		}
-
-		// search for action.yml or action.yaml file
-		ymlAction := filepath.Join(dirAction, "action.yml")
-		_, err = os.Stat(ymlAction)
-
-		ymlNotFound := os.IsNotExist(err)
-		if err != nil && !ymlNotFound {
-			return fmt.Errorf("error getting os.Stat on %s: %w", ymlAction, err)
-		}
-
-		if ymlNotFound {
-			yamlAction := filepath.Join(dirAction, "action.yaml")
-			_, err = os.Stat(yamlAction)
-
-			yamlNotFound := os.IsNotExist(err)
-			if err != nil && !yamlNotFound {
-				return fmt.Errorf("error getting os.Stat on %s: %w", yamlAction, err)
-			}
-
-			if !yamlNotFound {
-				ymlAction = yamlAction
-			} else {
-				continue
-			}
 		}
 
 		d.Actions[entry.Name()] = &action.Action{
 			Path:    ymlAction,
 			DirName: entry.Name(),
+		}
+	}
+
+	if len(overridePaths) == 0 {
+		return nil
+	}
+
+	if d.ExternalActions == nil {
+		d.ExternalActions = map[string]*action.Action{}
+	}
+
+	for actionPath, localPath := range overridePaths {
+		ymlAction, err := getActionYAMLFromPath(localPath)
+		if err != nil {
+			return err
+		}
+
+		if ymlAction == "" {
+			continue
+		}
+
+		d.ExternalActions[actionPath] = &action.Action{
+			Path:    ymlAction,
+			DirName: "",
 		}
 	}
 
@@ -309,6 +307,15 @@ func (d *DotGithub) getWorkflowsFromDir(path string) error {
 }
 
 func (d *DotGithub) processActions(ctx context.Context) error {
+	// get contents from already existing external actions that are overridden by local actions
+	var err error
+	for path, _ := range d.ExternalActions {
+		err = d.ExternalActions[path].Unmarshal(false)
+		if err != nil {
+			return fmt.Errorf("error unmarshaling external action overridden by a local file %s: %w", path, err)
+		}
+	}
+
 	// download all external actions used in actions' steps
 	reExternal := regexp.MustCompile(regexpExternalAction)
 
@@ -439,4 +446,43 @@ func (d *DotGithub) getActionHTTPResponse(
 	}
 
 	return resp, nil
+}
+
+func getActionYAMLFromPath(path string) (string, error) {
+	// only directories
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("error getting os.Stat on %s: %w", path, err)
+	}
+
+	if !fileInfo.IsDir() {
+		return "", nil
+	}
+
+	// search for action.yml or action.yaml file
+	ymlAction := filepath.Join(path, "action.yml")
+	_, err = os.Stat(ymlAction)
+
+	ymlNotFound := os.IsNotExist(err)
+	if err != nil && !ymlNotFound {
+		return "", fmt.Errorf("error getting os.Stat on %s: %w", ymlAction, err)
+	}
+
+	if !ymlNotFound {
+		return ymlAction, nil
+	}
+
+	yamlAction := filepath.Join(path, "action.yaml")
+	_, err = os.Stat(yamlAction)
+
+	yamlNotFound := os.IsNotExist(err)
+	if err != nil && !yamlNotFound {
+		return "", fmt.Errorf("error getting os.Stat on %s: %w", yamlAction, err)
+	}
+
+	if !yamlNotFound {
+		return yamlAction, nil
+	}
+
+	return "", nil
 }

--- a/pkg/dotgithub/dotgithub.go
+++ b/pkg/dotgithub/dotgithub.go
@@ -142,7 +142,6 @@ func (d *DotGithub) GetExternalAction(name string) *action.Action {
 	if d.ExternalActions == nil {
 		d.ExternalActions = map[string]*action.Action{}
 	}
-
 	return d.ExternalActions[name]
 }
 


### PR DESCRIPTION
This PR introduces an important fix to rules which are used for both actions and workflows. There was a bug where a rule which was meant for a workflow, was executed against the action as well. This is now fixed by introducing a field that determines whether the rule was created for action for a workflow, and by a condition which checks if that field equals the type of the file that is checked.

In addition to that, octo-linter will now be able to read an external action from a local directory. When an action in the step is private, octo-linter will not be able to download it. Hence the ability to put its name in the config, along with a path where it is available.

Docs have been updated.